### PR TITLE
Fix maven site

### DIFF
--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -7,6 +7,13 @@
         <groupId>com.javaacademy</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
+
+    <distributionManagement>
+        <site>
+            <url>crawler/target/site/</url>
+        </site>
+    </distributionManagement>
+
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,19 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>gemstone-release</id>
+            <name>GemStone Maven RELEASE Repository</name>
+            <url>http://dist.gemstone.com/maven/release</url>
+        </repository>
+        <repository>
+            <id>libs-release</id>
+            <name>Spring Maven libs-release Repository</name>
+            <url>http://repo.spring.io/libs-release</url>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <!--Spring Boot-->

--- a/springapp/pom.xml
+++ b/springapp/pom.xml
@@ -7,6 +7,13 @@
         <groupId>com.javaacademy</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
+
+    <distributionManagement>
+        <site>
+            <url>springapp/target/site/</url>
+        </site>
+    </distributionManagement>
+
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
 

--- a/springapp/src/main/resources/application.properties
+++ b/springapp/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 spring.datasource.url=jdbc:postgresql://localhost:5432/test_db
 spring.datasource.username=postgres
-spring.datasource.password=
+spring.datasource.password=12345
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/springapp/src/main/resources/application.properties
+++ b/springapp/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 spring.datasource.url=jdbc:postgresql://localhost:5432/test_db
 spring.datasource.username=postgres
-spring.datasource.password=12345
+spring.datasource.password=
 spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
Added repositories to pom.xml file in order to remove exceptions thrown during mvn site generation.
Added links to submodules to their pom files, now main index file has correct links to submodules' indexes files